### PR TITLE
updated code for rust 1.0.0-nightly compatibility

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6,7 +6,7 @@
 extern crate core;
 extern crate rlibc;
 
-use core::str::StrPrelude;
+use core::str::StrExt;
 
 #[lang = "stack_exhausted"] extern fn stack_exhausted() {}
 #[lang = "eh_personality"] extern fn eh_personality() {}


### PR DESCRIPTION
StrPrelude has been renamed to StrExt. This change make the project compile again!