### PR TITLE
Use core_str_ext feature for latest nightly

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,11 +1,10 @@
 #![no_std]
 
-#![feature(core)]
+#![feature(core_str_ext)]
 #![feature(no_std)]
 #![feature(lang_items)]
 #![feature(intrinsics)]
 
-extern crate core;
 extern crate rlibc;
 
 use core::str::StrExt;


### PR DESCRIPTION
Latest nightly seems to require this.
Might be good to note down in the README that nightly is required in the first place.

Should I just add that?